### PR TITLE
ci: add publish to npm workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,31 @@
+name: Publish to npm registry
+
+on:
+  release:
+    types:
+      - created
+  workflow_dispatch:
+    inputs:
+      version:
+        required: true
+        description: The version to release
+
+jobs:
+  btp:
+    runs-on: ubuntu-latest
+    name: Publish
+    steps:
+      - uses: actions/checkout@v2
+      - name: Bump version
+        run: |-
+          cat <<< $(jq '.version = (env.RELEASE_VERSION | sub("(^refs/tags/v)|(^v)"; ""))' package.json) > package.json
+          git config --local user.email "zepatrik@users.noreply.github.com"
+          git config --local user.name "zepatrik"
+          git add package.json
+          git commit -m "autogen: bump version"
+          git push -f "https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD:master
+        env:
+          RELEASE_VERSION: ${{ github.event.inputs.version || github.ref }}
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN_AENEASR }}


### PR DESCRIPTION
The workflow first updates the version in the package.json, commits that change and then runs `npm publish`. It is triggered by GitHub releases and can be manually dispatched.
This is heavily inspired by https://github.com/ory/prettier-styles/blob/master/.github/workflows/publish.yml and works in that repo.